### PR TITLE
Update buddyart's link to include https:// for team page

### DIFF
--- a/src/views/team/Team.vue
+++ b/src/views/team/Team.vue
@@ -105,7 +105,7 @@ const foundingMembers = [
         type: "twitter",
         handle: "Buddyart00",
       },
-      { url: "www.buddyart00.com", type: "webpage" },
+      { url: "https://www.buddyart00.com", type: "webpage" },
     ],
   },
   {


### PR DESCRIPTION
Fix buddyarts link on team page to include https so it doesn't open as a child address of seen.haus