### PR TITLE
feat(ProductCard/HeroAuction/MassDrops): bundle handling & slugs as full routes

### DIFF
--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -39,6 +39,7 @@
         >{{ title }}</span
         >
         <price-display
+            v-if="!shouldHidePrice"
             size="sm"
             class="items-end ml-2 -mt-0.5 md:mt-0.5"
             :class="isCollectableActive ? 'text-black' : 'text-gray-400'"
@@ -68,8 +69,8 @@
             class="text-black text-sm mt-2"
             :isAuction="isAuction"
             :class="isCollectableActive ? 'text-black' : 'text-gray-400'"
-            :startDate="startsAt"
-            :endDate="endsAt"
+            :startDate="getStartsAt"
+            :endDate="getEndsAt"
             @onProgress="updateProgress"
             @onTimerStateChange="updateCollectableState"
         />
@@ -82,8 +83,8 @@
               class="text-black text-sm mt-2"
               :isAuction="isAuction"
               :class="isCollectableActive ? 'text-black' : 'text-gray-400'"
-              :startDate="startsAt"
-              :endDate="endsAt"
+              :startDate="getStartsAt"
+              :endDate="getEndsAt"
               @onProgress="updateProgress"
               @onTimerStateChange="updateCollectableState"
           />
@@ -132,6 +133,42 @@ export default {
   props: {
     collectable: Object,
   },
+  computed: {
+    getStartsAt() {
+      if(this.bundleChildItems && this.bundleChildItems && this.bundleChildItems.length > 0) {
+        let startsAt = false;
+        for(let bundleItem of this.bundleChildItems) {
+          if(!startsAt) {
+            startsAt = bundleItem.starts_at;
+          }else if(bundleItem.starts_at < startsAt) {
+            startsAt = bundleItem.starts_at;
+          }
+        }
+        return startsAt;
+      }
+      return this.startsAt;
+    },
+    getEndsAt() {
+      if(this.bundleChildItems && this.bundleChildItems && this.bundleChildItems.length > 0) {
+        let endsAt = false;
+        for(let bundleItem of this.bundleChildItems) {
+          if(!endsAt) {
+            endsAt = bundleItem.ends_at;
+          }else if(bundleItem.ends_at > endsAt) {
+            endsAt = bundleItem.ends_at;
+          }
+        }
+        return endsAt;
+      }
+      return this.endsAt;
+    },
+    shouldHidePrice() {
+      if(this.bundleChildItems && this.bundleChildItems && this.bundleChildItems.length > 0) {
+        return true;
+      }
+      return false;
+    }
+  },
   setup(props) {
     const autoplay = true;
     // console.log('ProductCard', props.collectable);
@@ -169,6 +206,7 @@ export default {
       // setCollectable,
       // updateInformation,
       updateCollectableState,
+      bundleChildItems,
     } = useCollectableInformation(props.collectable);
 
     const addTime = function () {
@@ -219,6 +257,7 @@ export default {
       addTime,
       handleHover,
       updateCollectableState,
+      bundleChildItems,
     };
   },
 };

--- a/src/hooks/useCollectableInformation.js
+++ b/src/hooks/useCollectableInformation.js
@@ -25,6 +25,7 @@ export default function useCollectableInformation(initialCollectable = {}) {
 
     const collectable = ref(initialCollectable);
     const events = ref(collectable.value.events || []);
+    const bundleChildItems = computed(() => collectable.value.bundleChildItems);
     const price = ref(0.0);
     const nextBidPrice = ref(0.0);
     const priceUSD = ref(0.0);
@@ -292,6 +293,7 @@ export default function useCollectableInformation(initialCollectable = {}) {
         title,
         description,
         events,
+        bundleChildItems,
         startsAt,
         endsAt,
         liveStatus,

--- a/src/hooks/useDropsWithPagination.js
+++ b/src/hooks/useDropsWithPagination.js
@@ -4,7 +4,12 @@ import PURCHASE_TYPE from "@/constants/PurchaseTypes.js";
 import { computed, reactive } from "vue";
 
 
-export default function useDropsWithPagination(artistId = null, perPage = 12, includeIsHiddenFromDropList = false) {
+export default function useDropsWithPagination(
+  artistId = null,
+  perPage = 12,
+  includeIsHiddenFromDropList = false,
+  bundleChildId = false
+) {
   const state = reactive({
     items: [null, null, null, null, null, null],
     perPage: perPage,
@@ -40,6 +45,9 @@ export default function useDropsWithPagination(artistId = null, perPage = 12, in
     }
     if (includeIsHiddenFromDropList !== false) {
       filtrationOptions.includeIsHiddenFromDropList = true;
+    }
+    if(bundleChildId !== false){
+      filtrationOptions.bundleChildId = bundleChildId;
     }
 
     const { data, metadata } = await CollectablesService.list(

--- a/src/views/drops/Drops.vue
+++ b/src/views/drops/Drops.vue
@@ -43,7 +43,7 @@
           <product-card
             v-if="collectable != null"
             :collectable="collectable"
-            @click="navigateToCollectable(collectable.slug)"
+            @click="navigateToCollectable(collectable.slug, collectable.is_slug_full_route)"
           />
           <div
             v-else
@@ -121,11 +121,17 @@ export default {
       filterEditions.value = event;
       paginatedCollectables.filter(filterAuctions.value, filterEditions.value);
     }
-    const navigateToCollectable = function (slug) {
-      router.push({
-        name: "collectableAuction",
-        params: { slug: slug },
-      });
+    const navigateToCollectable = function (slug, isSlugFullRoute) {
+      if(isSlugFullRoute) {
+        router.push({
+          name: slug,
+        });
+      } else {
+        router.push({
+          name: "collectableAuction",
+          params: { slug: slug },
+        });
+      }
     };
 
     return {

--- a/src/views/home/Home.vue
+++ b/src/views/home/Home.vue
@@ -43,7 +43,7 @@
           <product-card
             v-if="collectable != null"
             :collectable="collectable"
-            @click="navigateToCollectable(collectable.slug)"
+            @click="navigateToCollectable(collectable.slug, collectable.is_slug_full_route)"
           />
           <div
             v-else
@@ -65,7 +65,7 @@
           <product-card
             v-if="collectable != null"
             :collectable="collectable"
-            @click="navigateToCollectable(collectable.slug)"
+            @click="navigateToCollectable(collectable.slug, collectable.is_slug_full_route)"
           />
           <div
             v-else
@@ -203,11 +203,17 @@ export default {
 
     paginatedCollectables.load();
 
-    const navigateToCollectable = function (slug) {
-      router.push({
-        name: "collectableAuction",
-        params: { slug: slug },
-      });
+    const navigateToCollectable = function (slug, isSlugFullRoute) {
+      if(isSlugFullRoute) {
+        router.push({
+          name: slug,
+        });
+      }else{
+        router.push({
+          name: "collectableAuction",
+          params: { slug: slug },
+        });
+      }
     };
 
     const paginatedArtists = useArtistsWithPagination();

--- a/src/views/massDrops/MassDrop.vue
+++ b/src/views/massDrops/MassDrop.vue
@@ -147,7 +147,7 @@ export default {
     const listOfArtists = computed(() => paginatedArtists.listOfArtists.value);
     paginatedArtists.load();
 
-    const paginatedCollectables = useDropsWithPagination(props.drop.artistId, props.drop.numberOfItems, true);
+    const paginatedCollectables = useDropsWithPagination(null, props.drop.numberOfItems, true, props.drop.bundleChildId);
     const listOfCollectables = computed(() => {
       let list = paginatedCollectables.listOfCollectables.value;
       return orderBy(list, 'id', "asc")

--- a/src/views/massDrops/Spaaaaace.vue
+++ b/src/views/massDrops/Spaaaaace.vue
@@ -19,6 +19,7 @@ export default {
       metaTitle: "Spaace",
       dropTitle: "Space NFT",
       artistSlug: 'jisbar',
+      bundleChildId: 'jisbar-space',
       gridWidth: 4,
       artistId: 29,
       numberOfItems: 40,

--- a/src/views/profile/ArtistProfile.vue
+++ b/src/views/profile/ArtistProfile.vue
@@ -36,7 +36,7 @@
           <product-card
             v-if="collectable != null"
             :collectable="collectable"
-            @click="navigateToCollectable(collectable.slug)"
+            @click="navigateToCollectable(collectable.slug, collectable.is_slug_full_route)"
           />
           <div
             v-else
@@ -96,11 +96,17 @@ export default {
     const listOfCollectables = computed(
       () => paginatedCollectables.listOfCollectables.value
     );
-    const navigateToCollectable = function (slug) {
-      router.push({
-        name: "collectableAuction",
-        params: { slug: slug },
-      });
+    const navigateToCollectable = function (slug, isSlugFullRoute) {
+      if(isSlugFullRoute) {
+        router.push({
+          name: slug,
+        });
+      }else{
+        router.push({
+          name: "collectableAuction",
+          params: { slug: slug },
+        });
+      }
     };
 
     return {

--- a/src/views/profile/Profile.vue
+++ b/src/views/profile/Profile.vue
@@ -74,7 +74,7 @@
                 v-else
                 :collectable="collectable.data"
                 @click="
-                  navigateToCollectable(collectable.data.slug)
+                  navigateToCollectable(collectable.data.slug, collectable.data.is_slug_full_route)
                 "
               />
             </template>
@@ -204,11 +204,17 @@ export default {
       collection.loadMore();
     };
 
-    const navigateToCollectable = function (slug) {
-      router.push({
-        name: "collectableAuction",
-        params: { slug: slug },
-      });
+    const navigateToCollectable = function (slug, isSlugFullRoute) {
+      if(isSlugFullRoute) {
+        router.push({
+          name: slug,
+        });
+      }else{
+        router.push({
+          name: "collectableAuction",
+          params: { slug: slug },
+        });
+      }
     };
 
     const listOfCollectables = computed(


### PR DESCRIPTION
- Allow drop cards to navigate to slugs as full URLs
- enable bundle parents shown as product cards / hero auction to use earliest startDate & latest endDate
- enable space massDrop to query by children bundleId
- hide prices on bundle product cards & hero auction