### PR TITLE
Hard break image collage container for smaller display sizes

### DIFF
--- a/src/views/massDrops/MassDrop.vue
+++ b/src/views/massDrops/MassDrop.vue
@@ -290,4 +290,18 @@ export default {
 .artist-text {
   line-height: 1.75rem;
 }
+
+/* Responsive hotfix for image collage */
+@media screen and (max-width: 767px) {
+  .collage-image {
+    transform: scale(0.75);
+    margin: -100px -140px;
+  }
+}
+@media screen and (max-width: 530px) {
+  .collage-image {
+    transform: scale(0.5);
+    margin: -240px -190px;
+  }
+}
 </style>


### PR DESCRIPTION
Apply negative margin and scale transformation on image collage container to accommodate display without cropping contents. Uses two targeted media queries to stack on top of theme layer container sizes.