### PR TITLE
fix: missing value on self-minting stepper mint step

### DIFF
--- a/src/views/selfCreate/components/Mint.vue
+++ b/src/views/selfCreate/components/Mint.vue
@@ -282,7 +282,7 @@
                 :creatorAccount="creatorData.account"
                 :creatorProfilePicture="creatorData.profilePicture"
                 :creatorUsername="creatorData.username"
-                :creatorSlug="processData.creatorUsername || creatorData.username"
+                :creatorSlug="creatorData.username"
                 creatorType="user"
                 :mediaUrl="mediaUrl"
                 :collectableState="collectableState"


### PR DESCRIPTION
the `processData` property isn't available in this `Mint` component. Instead indivitual properties are passed onto this component. Tho, we already have this specific data available via `creatorData.username`