### PR TITLE
fix: staking distribution data error on staking page load

### DIFF
--- a/src/views/stake/components/DistributionCard.vue
+++ b/src/views/stake/components/DistributionCard.vue
@@ -103,8 +103,7 @@ export default {
     })
 
     const loadLatestDistribution = async () => {
-      if(distributionPoolContract.value) {
-
+      if (distributionPoolContract.value?.contract) {
         let events = await distributionPoolContract.value.contract.queryFilter("SwapForMinimum");
 
         let latestDistributionBlockNumber = null;


### PR DESCRIPTION
```
Uncaught (in promise) TypeError: Cannot read properties of null (reading 'queryFilter')
    at _callee4$ (DistributionCard.vue?2e0f:105:1)
    at tryCatch (runtime.js?96cf:63:1)
    at Generator.invoke [as _invoke] (runtime.js?96cf:293:1)
    at Generator.eval [as next] (runtime.js?96cf:118:1)
    at asyncGeneratorStep (asyncToGenerator.js?1da1:3:1)
    at _next (asyncToGenerator.js?1da1:25:1)
    at eval (asyncToGenerator.js?1da1:32:1)
    at new Promise (<anonymous>)
    at eval (asyncToGenerator.js?1da1:21:1)
    at loadLatestDistribution (DistributionCard.vue?2e0f:105:1)
```